### PR TITLE
fix frontend username validation in accordance to backend user dto

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -23,7 +23,7 @@ const LoginPage = () => {
   // walidacja nazwy użytkownika
   const validateUsername = (name: string) => {
     // maks. 32 znaki alfanumeryczne (bez spacji, znaków specjalnych)
-    const nameRegex = /^[a-zA-Z0-9]{3,32}$/;
+    const nameRegex = /^[a-zA-Z0-9_.-]{3,32}$/;
     const errorMessage = "Nazwa użytkownika może mieć maksymalnie 32 znaki alfanumeryczne!"
     return nameRegex.test(name) ? "" : errorMessage;
   }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -25,7 +25,7 @@ const RegisterPage = () => {
   // walidacja nazwy użytkownika
   const validateUsername = (name: string) => {
     // maks. 32 znaki alfanumeryczne (bez spacji, znaków specjalnych)
-    const nameRegex = /^[a-zA-Z0-9]{3,32}$/;
+    const nameRegex = /^[a-zA-Z0-9_.-]{3,32}$/;
     const errorMessage = "Nazwa użytkownika może mieć maksymalnie 32 znaki alfanumeryczne!"
     return nameRegex.test(name) ? "" : errorMessage;
   }


### PR DESCRIPTION
- Changed the required complexity of username validation in accordance to backend, that is **3-32 character length, only letters, numbers, hyphens ( - ), underscores ( _ ) and dots ( . ).**